### PR TITLE
Fix timer

### DIFF
--- a/src/components/moments-ago.vue
+++ b/src/components/moments-ago.vue
@@ -66,6 +66,10 @@ export default {
     }
   },
 
+  beforeMount() {
+    this.getSeconds(this.date);
+  },
+
   mounted() {
     setInterval(() => {
       this.getSeconds(this.date);


### PR DESCRIPTION
I added `beforeMount()`, so that the date is updated right before mounting the Vue component and it doesn't have to wait for the first timer occurrence. When you open the page with this component, it immediately shows the human date form.