### PR TITLE
Removed default style

### DIFF
--- a/src/components/moments-ago.vue
+++ b/src/components/moments-ago.vue
@@ -120,7 +120,5 @@ export default {
 </script>
 
 <style scoped>
-.vue-moments-ago {
-  font-size: 12px;
-}
+
 </style>


### PR DESCRIPTION
I removed the default style because it's unnecessary and applying a default style to a purely functional component makes the component less portable. It's better to add styles from a higher level (e.g. from other pages or components you use `<vue-moments-ago>` in). That makes it also easier to maintain.