### PR TITLE
Fix + updates for vue-moments-ago

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ export default{
 In the template, use:
 
 ```
-<vue-moments-ago prefix="posted" suffix="ago" date="2018-05-02T20:22:22.285Z" lang="en"></vue-moments-ago>
+<vue-moments-ago prefix="posted" suffix="ago" date="2018-05-02T20:22:22.285Z" lang="en" />
 ```
 
 Result:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # vue-moments-ago
 
-A Vue.js component for updating human readable time format.
-
-eg:
+A Vue.js component for updating human readable time format, eg:
 
 ```
 posted 2 minutes ago
 ```
 
-this is automatically updated without any refresh. Checkout this [Live Demo](https://codesandbox.io/s/m4x9kw090p)
+This is automatically updated without any refresh. Checkout this [Live Demo](https://codesandbox.io/s/m4x9kw090p)
 
 ### Install
 
@@ -28,13 +26,13 @@ export default{
 }
 ```
 
-in the template, use:
+In the template, use:
 
 ```
 <vue-moments-ago prefix="posted" suffix="ago" date="2018-05-02T20:22:22.285Z" lang="en"></vue-moments-ago>
 ```
 
-result:
+Result:
 
 ```
  posted 2 minutes ago
@@ -50,6 +48,7 @@ result:
 | language | false    | String | default is "en"                                       |
 
 ### Support Language
+### Supported languages
 
 We support English, Korean and Japanese. y Language options are available. default value is "en".
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,20 @@ Result:
 
 ### Props
 
-| Props    | Required | Type   | Definition                                            |
-| :------- | :------- | :----- | :---------------------------------------------------- |
-| prefix   | false    | String | Any prefix string you want to add to the output       |
-| suffix   | false    | String | Any suffix string you want to add to the output       |
-| date     | true     | String | The date is in ISO 8601 (default format of moment.js) |
-| language | false    | String | default is "en"                                       |
+| Props        | Required | Type             | Definition                                            |
+| :----------- | :------- | :--------------- | :---------------------------------------------------- |
+| prefix       | false    | String           | Any prefix string you want to add to the output       |
+| suffix       | false    | String           | Any suffix string you want to add to the output       |
+| date         | true     | String           | The date is in ISO 8601 (default format of moment.js) |
+| language     | false    | String           | default is "en"                                       |
+| elementStyle | false    | String \| Object | Apply a `style` attr. on the wrapper element *        |
+| elementClass | false    | String \| Object | Apply a `class` attr. on the wrapper element *        |
 
-### Support Language
+\* elementStyle / elementClass: either a string, eg.  
+`elementStyle="border: 1px solid red"`  
+... or a style Object:  
+`:elementStyle="{ border: '1px solid orange' }"`
+
 ### Supported languages
 
 We support English, Korean and Japanese. y Language options are available. default value is "en".

--- a/src/components/moments-ago.vue
+++ b/src/components/moments-ago.vue
@@ -67,9 +67,9 @@ export default {
   },
 
   mounted() {
-    setInterval(() => {
+    this.$nextTick(() => {
       this.getSeconds(this.date);
-    }, 1000);
+    });
   },
 
   computed: {

--- a/src/components/moments-ago.vue
+++ b/src/components/moments-ago.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="date" class="vue-moments-ago"
+  <span v-if="date" class="vue-moments-ago" :style="elementStyle" :class="elementClass"
     >{{ prefix }} {{ humanFormatted }} {{ suffix }}</span
   >
 </template>
@@ -63,6 +63,14 @@ export default {
     lang: {
       type: String,
       default: "en"
+    },
+    elementClass: {
+      type: String | Object,
+      default: ""
+    },
+    elementStyle: {
+      type: String | Object,
+      default: ""
     }
   },
 


### PR DESCRIPTION
Biggest improvement: no longer a one second delay in displaying the correct "moment ago" value. Nice addition: allow setting style(s)/class(es) on the container span from the parent.